### PR TITLE
Scroll cheatsheet buffer to top on open

### DIFF
--- a/cheatsheet.el
+++ b/cheatsheet.el
@@ -141,6 +141,7 @@
   (cheatsheet-mode)
   (erase-buffer)
   (insert (cheatsheet--format))
+  (beginning-of-buffer)
   (setq buffer-read-only t))
 
 (define-derived-mode cheatsheet-mode fundamental-mode "Cheat Sheet"


### PR DESCRIPTION
I found it disorienting to have my cheatsheet start at different offsets depending on the window split size so I made this change to have it always start at the top